### PR TITLE
Update main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"yaml"
 	],
 	"license": "MIT",
-	"main": "index.js",
+	"main": "dist/index.js",
 	"name": "@elsikora/eslint-config",
 	"peerDependencies": {
 		"eslint": "^8.0.0",


### PR DESCRIPTION
This change modifies the main field in package.json to point to "dist/index.js" instead of just "index.js". This update is necessary to correct the entry point our package refers to when it's imported by other packages.