### PR TITLE
Update build script command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
 	},
 	"repository": "ElsiKora/ESLint-Config",
 	"scripts": {
-		"build": "npx babel-cli src --out-dir dist",
+		"build": "npx babel src --out-dir dist",
 		"format": "prettier --write \"**/*.{js,json}\"",
 		"lint": "eslint ./src --ext .js,.json --fix",
 		"patch": "changeset",


### PR DESCRIPTION
This commit changes the build command script in package.json to use "babel" instead of "babel-cli". This ensures code compatibility across different environments and enhances consistency in the build process.