### PR TITLE
Simplify build script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,11 +76,10 @@
 	},
 	"repository": "ElsiKora/ESLint-Config",
 	"scripts": {
-		"build": "npm run prebuild && npx babel src --out-dir dist && npm run postbuild",
+		"build": "npm run prebuild && npx babel src --out-dir .",
 		"format": "prettier --write \"**/*.{js,json}\"",
 		"lint": "eslint ./src --ext .js,.json --fix",
 		"patch": "changeset",
-		"postbuild": "mv ./dist/* ./",
 		"prebuild": "rimraf dist",
 		"release": "npm install && npm run build && changeset publish"
 	},


### PR DESCRIPTION
Removed postbuild script and modified the build script in package.json to directly output files to the current directory. Adjusted instructions in README for extending configurations.