### PR TITLE
Update dependency version and eslint format for Readonly properties

### DIFF
--- a/.changeset/neat-clouds-unite.md
+++ b/.changeset/neat-clouds-unite.md
@@ -1,0 +1,5 @@
+---
+"@elsikora/eslint-config": patch
+---
+
+Update dependency version and eslint format for Readonly properties

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 	"name": "@elsikora/eslint-config",
 	"peerDependencies": {
 		"@elsikora/eslint-plugin-nestjs-typed": ">1.0.0",
-		"@elsikora/eslint-plugin-sort-decorators": ">0.0.0",
+		"@elsikora/eslint-plugin-sort-decorators": ">0.1.0",
 		"@stylistic/eslint-plugin": ">1.0.0",
 		"@stylistic/eslint-plugin-ts": ">1.0.0",
 		"@typescript-eslint/eslint-plugin": ">7.0.0",

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -66,7 +66,7 @@ export default {
 						selector: "typeLike",
 					},
 					{
-						format: ["PascalCase"], // Readonly properties should use PascalCase.
+						format: ["UPPER_CASE"], // Readonly properties should use PascalCase.
 						modifiers: ["readonly"],
 						selector: "property",
 					},


### PR DESCRIPTION
Bumped up the version of "@elsikora/eslint-plugin-sort-decorators" in package.json. Also, changed the format required for Readonly properties from "PascalCase" to "UPPER_CASE" in typescript eslint rules, making it more consistent and easier to identify ReadOnly properties.