### PR TITLE
ci(ci): Use explicit 'ubuntu-latest' for runner configuration

### DIFF
--- a/.github/workflows/mirror-to-codecommit.yml
+++ b/.github/workflows/mirror-to-codecommit.yml
@@ -1,7 +1,6 @@
 name: Mirror to CodeCommit
 
 env:
-  RUNNER_OS: ubuntu-latest
   CHECKOUT_DEPTH: 0
 
 on: push
@@ -9,7 +8,7 @@ on: push
 jobs:
   mirror_to_codecommit:
     name: Mirror to CodeCommit
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/qodana-quality-scan.yml
+++ b/.github/workflows/qodana-quality-scan.yml
@@ -2,7 +2,6 @@ name: Qodana Quality Scan
 
 env:
   NODE_VERSION: 20
-  RUNNER_OS: ubuntu-latest
   CHECKOUT_DEPTH: 0
 
 on: push
@@ -10,7 +9,7 @@ on: push
 jobs:
   qodana_quality_scan:
     name: Qodana Quality Scan
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release And Publish
 
 env:
-  RUNNER_OS: ubuntu-latest
   NODE_VERSION: 20
 
 on:
@@ -13,7 +12,7 @@ on:
 jobs:
   release:
     name: Release And Publish
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/snyk-security-scan.yml
+++ b/.github/workflows/snyk-security-scan.yml
@@ -2,7 +2,6 @@ name: Snyk Security Scan
 
 env:
   NODE_VERSION: 20
-  RUNNER_OS: ubuntu-latest
   SNYK_GLOBAL_PACKAGES: snyk snyk-to-html
 
 on: push
@@ -10,7 +9,7 @@ on: push
 jobs:
   snyk_security_scan:
     name: Snyk Security Scan
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,11 @@ on: push
 
 env:
   NODE_VERSION: 20
-  RUNNER_OS: ubuntu-latest
 
 jobs:
   test:
     name: Test
-    runs-on: ${{ env.RUNNER_OS }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Replaced the use of the `RUNNER_OS` environment variable with a direct reference to `ubuntu-latest` in all GitHub workflow files. This simplifies configuration and reduces unnecessary abstraction for better clarity and maintainability.