### PR TITLE
refactor(deps): move react eslint plugin to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
 		"eslint-plugin-package-json": "^0.26.2",
 		"eslint-plugin-perfectionist": "^4.9.0",
 		"eslint-plugin-prettier": "^5.2.3",
-		"eslint-plugin-react": "^7.37.4",
 		"eslint-plugin-regexp": "^2.7.0",
 		"eslint-plugin-sonarjs": "^3.0.2",
 		"eslint-plugin-tailwindcss": "^3.18.0",
@@ -135,9 +134,13 @@
 		"eslint-plugin-jsx-a11y": "^6.10.2",
 		"eslint-plugin-n": "^17.15.1",
 		"eslint-plugin-ng-module-sort": "^1.3.1",
+		"eslint-plugin-react": "^7.37.4",
 		"eslint-plugin-typeorm-typescript": "^0.5.0"
 	},
 	"peerDependenciesMeta": {
+		"eslint-plugin-react": {
+			"optional": true
+		},
 		"eslint-plugin-n": {
 			"optional": true
 		},

--- a/src/infrastructure/config/unicorn.ts
+++ b/src/infrastructure/config/unicorn.ts
@@ -9,6 +9,7 @@ export default [
 	...formatConfig([unicorn.configs.recommended]),
 	{
 		rules: {
+			[formatRuleName("n/no-process-exit")]: "off", // Allow process.exit to be used in code, as it is a valid way to exit a Node.js process.
 			[formatRuleName("unicorn/filename-case")]: "off", // Disable filename casing rules to allow flexibility in project naming conventions.
 			[formatRuleName("unicorn/no-null")]: "off", // Allow null values to be used in code, as they are a valid data type in JavaScript.
 			[formatRuleName("unicorn/prefer-top-level-await")]: "off", // Allow flexibility in using top-level await, accommodating different project structures and initialization patterns.


### PR DESCRIPTION
Moves eslint-plugin-react from dependencies to peerDependencies and marks it as optional. This allows projects that don't use React to avoid installing this plugin unnecessarily. Also added a rule configuration to disable the n/no-process-exit rule in the unicorn config.