### PR TITLE
build(deps): relax peer dependencies version constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,13 +128,13 @@
 		"vitest": "^3.0.7"
 	},
 	"peerDependencies": {
-		"@elsikora/eslint-plugin-nestjs-typed": "^3.0.1",
-		"@eslint-react/eslint-plugin": "^1.27.0",
-		"@next/eslint-plugin-next": "^15.2.1",
-		"eslint-plugin-jsx-a11y": "^6.10.2",
-		"eslint-plugin-n": "^17.15.1",
-		"eslint-plugin-ng-module-sort": "^1.3.1",
-		"eslint-plugin-react": "^7.37.4",
+		"@elsikora/eslint-plugin-nestjs-typed": "^3.0.0",
+		"@eslint-react/eslint-plugin": "^1.0.0",
+		"@next/eslint-plugin-next": "*",
+		"eslint-plugin-jsx-a11y": "^6.0.0",
+		"eslint-plugin-n": "^17.0.0",
+		"eslint-plugin-ng-module-sort": "^1.0.0",
+		"eslint-plugin-react": "^7.0.0",
 		"eslint-plugin-typeorm-typescript": "^0.5.0"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
Update peer dependencies to use more flexible version ranges. This allows for better compatibility with different project setups without forcing exact versions.