### PR TITLE
refactor(eslint-config): standardize file pattern matching across plu…

### DIFF
--- a/src/infrastructure/config/css.ts
+++ b/src/infrastructure/config/css.ts
@@ -7,8 +7,14 @@ import { formatPluginName } from "../utility/format-plugin-name.utility";
 
 export default [
 	{
+		...formatConfig([css.configs.recommended])[0],
 		files: ["**/*.css"],
 		language: `${formatPluginName("css")}/css`,
-		...formatConfig([css.configs.recommended])[0],
+	},
+	{
+		files: ["**/*.css"],
+		rules: {
+			[`${formatPluginName("css")}/no-invalid-at-rules`]: "off",
+		},
 	},
 ] as Array<Linter.Config>;

--- a/src/infrastructure/config/javascript.ts
+++ b/src/infrastructure/config/javascript.ts
@@ -3,7 +3,10 @@ import type { Linter } from "eslint";
 import js from "@eslint/js";
 
 export default [
-	js.configs.recommended,
+	{
+		...js.configs.recommended,
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
 	{
 		rules: {
 			"no-await-in-loop": "off", // Allow await in loops

--- a/src/infrastructure/config/jsdoc.ts
+++ b/src/infrastructure/config/jsdoc.ts
@@ -6,9 +6,12 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatPluginName } from "../utility/format-plugin-name.utility";
 
 export default [
-	formatConfig([jsdoc.configs["flat/recommended"]])[0],
 	{
-		files: ["**/*.js"],
+		...formatConfig([jsdoc.configs["flat/recommended"]])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		plugins: {
 			[formatPluginName("jsdoc")]: jsdoc,
 		},

--- a/src/infrastructure/config/json.ts
+++ b/src/infrastructure/config/json.ts
@@ -4,4 +4,8 @@ import eslintPluginJsonc from "eslint-plugin-jsonc";
 
 import { formatConfig } from "../utility/format-config.utility";
 
-export default [...formatConfig([...eslintPluginJsonc.configs["flat/recommended-with-jsonc"]])] as Array<Linter.Config>;
+export default [
+	{
+		...formatConfig([...eslintPluginJsonc.configs["flat/recommended-with-jsonc"]])[0],
+	},
+] as Array<Linter.Config>;

--- a/src/infrastructure/config/next.ts
+++ b/src/infrastructure/config/next.ts
@@ -32,6 +32,7 @@ export default [
 		},
 	},
 	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		plugins: {
 			// eslint-disable-next-line @elsikora-typescript/no-unsafe-argument,@elsikora-sonar/no-duplicate-string
 			[formatPluginName("@next/next")]: fixupPluginRules(next),
@@ -61,6 +62,7 @@ export default [
 		},
 	},
 	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		rules: {
 			[`${formatPluginName("jsx-a11y")}/alt-text`]: "off",
 			[`${formatPluginName("react")}/prop-types`]: "off",

--- a/src/infrastructure/config/node.ts
+++ b/src/infrastructure/config/node.ts
@@ -6,8 +6,12 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatRuleName } from "../utility/format-rule-name.utility";
 
 export default [
-	...formatConfig([nPlugin.configs["flat/recommended"]]),
 	{
+		...formatConfig([nPlugin.configs["flat/recommended"]])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		rules: {
 			[formatRuleName("n/exports-style")]: ["error", "exports"],
 			[formatRuleName("n/no-missing-import")]: "off",

--- a/src/infrastructure/config/perfectionist.ts
+++ b/src/infrastructure/config/perfectionist.ts
@@ -6,8 +6,12 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatRuleName } from "../utility/format-rule-name.utility";
 
 export default [
-	...formatConfig([perfectionist.configs["recommended-alphabetical"]]),
 	{
+		...formatConfig([perfectionist.configs["recommended-alphabetical"]])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		rules: {
 			[formatRuleName("perfectionist/sort-imports")]: [
 				"error",

--- a/src/infrastructure/config/regexp.ts
+++ b/src/infrastructure/config/regexp.ts
@@ -4,4 +4,9 @@ import * as regexpPlugin from "eslint-plugin-regexp";
 
 import { formatConfig } from "../utility/format-config.utility";
 
-export default [...formatConfig([regexpPlugin.configs["flat/recommended"]])] as Array<Linter.Config>;
+export default [
+	{
+		...formatConfig([regexpPlugin.configs["flat/recommended"]])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+] as Array<Linter.Config>;

--- a/src/infrastructure/config/sonar.ts
+++ b/src/infrastructure/config/sonar.ts
@@ -9,8 +9,12 @@ const congnitiveComplexity: number = 100;
 const duplicateStringThreshold: number = 10;
 
 export default [
-	...formatConfig([sonarjs.configs.recommended]),
 	{
+		...formatConfig([sonarjs.configs.recommended])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		rules: {
 			[formatRuleName("sonarjs/bool-param-default")]: "error", // Require default values for boolean parameters to improve readability.
 			[formatRuleName("sonarjs/cognitive-complexity")]: ["error", congnitiveComplexity], // Set a high threshold for cognitive complexity to allow complex but manageable functions.

--- a/src/infrastructure/config/unicorn.ts
+++ b/src/infrastructure/config/unicorn.ts
@@ -6,8 +6,12 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatRuleName } from "../utility/format-rule-name.utility";
 
 export default [
-	...formatConfig([unicorn.configs.recommended]),
 	{
+		...formatConfig([unicorn.configs.recommended])[0],
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 		rules: {
 			[formatRuleName("n/no-process-exit")]: "off", // Allow process.exit to be used in code, as it is a valid way to exit a Node.js process.
 			[formatRuleName("unicorn/filename-case")]: "off", // Disable filename casing rules to allow flexibility in project naming conventions.

--- a/src/test/e2e/eslint.test.ts
+++ b/src/test/e2e/eslint.test.ts
@@ -70,6 +70,7 @@ describe("ESLint Config E2E Tests", () => {
 			const eslint: ESLint = await createEsLintInstance({
 				withNest: true,
 				withTypescript: true,
+				withSonar: true,
 			});
 
 			const results = await eslint.lintFiles([getFixturePath("nest/valid/clean.controller.fixture.ts")]);


### PR DESCRIPTION
…gin configurations

Restructured eslint configuration files to consistently specify file patterns (*.js, *.jsx, *.ts, *.tsx) across all plugin configurations. This ensures rules are properly scoped to the intended file types.

Also disabled the CSS 'no-invalid-at-rules' rule and added the Sonar plugin to the test suite.