### PR TITLE
chore(eslint): disable eslint-react filename naming convention rule

### DIFF
--- a/src/infrastructure/config/next.ts
+++ b/src/infrastructure/config/next.ts
@@ -67,6 +67,7 @@ export default [
 			[`${formatPluginName("jsx-a11y")}/alt-text`]: "off",
 			[`${formatPluginName("react")}/prop-types`]: "off",
 			[`${formatPluginName("react")}/react-in-jsx-scope`]: "off",
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename`)]: "off",
 		},
 	},
 ] as Array<Linter.Config>;


### PR DESCRIPTION
Turn off the ESLint React filename naming convention rule to prevent issues with our existing file naming patterns.