### PR TITLE
feat(eslint): disable tailwindcss custom classname rule

### DIFF
--- a/src/infrastructure/config/tailwind-css.ts
+++ b/src/infrastructure/config/tailwind-css.ts
@@ -4,6 +4,14 @@ import type { Linter } from "eslint";
 import tailwind from "eslint-plugin-tailwindcss";
 
 import { formatConfig } from "../utility/format-config.utility";
+import { formatPluginName } from "../utility/format-plugin-name.utility";
 
-// eslint-disable-next-line @elsikora-typescript/no-unsafe-argument,@elsikora-typescript/no-unsafe-member-access,@elsikora-typescript/no-unsafe-assignment
-export default [...formatConfig([...tailwind.configs["flat/recommended"]])] as Array<Linter.Config>;
+export default [
+	// eslint-disable-next-line @elsikora-typescript/no-unsafe-argument,@elsikora-typescript/no-unsafe-member-access,@elsikora-typescript/no-unsafe-assignment
+	...formatConfig([...tailwind.configs["flat/recommended"]]),
+	{
+		rules: {
+			[`${formatPluginName("tailwindcss")}/no-custom-classname`]: "off",
+		},
+	},
+] as Array<Linter.Config>;

--- a/src/infrastructure/constant/utility/plugin-map.constant.ts
+++ b/src/infrastructure/constant/utility/plugin-map.constant.ts
@@ -19,6 +19,7 @@ export const PLUGIN_MAP: Record<string, string> = {
 	prettier: "@elsikora-prettier",
 	react: "@elsikora/react/2",
 	sonarjs: "@elsikora-sonar",
+	tailwindcss: "@elsikora/tailwindcss",
 	unicorn: "@elsikora-unicorn",
 };
 


### PR DESCRIPTION
Modified the tailwind ESLint configuration to turn off the no-custom-classname rule. This allows for more flexibility in class naming. Also added tailwindcss to the plugin map constant for proper rule formatting.