### PR TITLE
refactor(config): simplify react configuration handling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,6 +59,7 @@ export default [
 		withPackageJson: true,
 		withPerfectionist: true,
 		withPrettier: true,
+		withReact: true,
 		withRegexp: true,
 		withSonar: true,
 		withStylistic: true,

--- a/src/application/factory/config.factory.ts
+++ b/src/application/factory/config.factory.ts
@@ -4,8 +4,6 @@ import type { IConfigOptions } from "../../domain/interface/config-options.inter
 import type { TConfigLoader } from "../../domain/type/config-loader.type";
 import type { TConfigModule } from "../../domain/type/config-module.type";
 
-import loadConfig from "../../infrastructure/config/react";
-
 /**
  * Factory class for generating ESLint configurations based on provided options.
  * Maps configuration flags to their respective module loaders and dynamically imports
@@ -94,10 +92,6 @@ export class ConfigFactory {
 			// Check if the default export is a function or an array
 			if (typeof defaultExport === "function") {
 				// For react config, pass the withNext option
-				if (name === "react") {
-					return loadConfig(this.currentOptions?.withNext ?? false);
-				}
-
 				return defaultExport();
 			}
 

--- a/src/infrastructure/config/react.ts
+++ b/src/infrastructure/config/react.ts
@@ -8,94 +8,92 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatPluginName } from "../utility/format-plugin-name.utility";
 import { formatRuleName } from "../utility/format-rule-name.utility";
 
-export default function loadConfig(withNext: boolean = false): Array<Linter.Config> {
-	return [
-		{
-			settings: {
-				react: {
-					version: "detect",
-				},
+export default [
+	{
+		settings: {
+			react: {
+				version: "detect",
 			},
 		},
-		{
-			plugins: {
-				[formatPluginName("react")]: react2,
-			},
+	},
+	{
+		plugins: {
+			[formatPluginName("react")]: react2,
 		},
-		{
-			// @ts-ignore
-			...formatConfig([react.configs.recommended])[0],
-			files: ["**/*.js", "**/*.jsx"],
-			languageOptions: {
-				parserOptions: {
-					ecmaFeatures: {
-						// eslint-disable-next-line @elsikora-typescript/naming-convention
-						jsx: true,
-					},
-					ecmaVersion: "latest",
-				},
-			},
-		},
-		{
-			files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
-			rules: {
-				[formatRuleName(`${formatPluginName("@eslint-react/hooks-extra")}/no-direct-set-state-in-use-effect`)]: "error",
-				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/context-name`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/checked-requires-onchange-or-readonly`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/default-props-match-prop-types`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/function-component-definition`)]: [
-					"error",
-					{
-						namedComponents: "arrow-function",
-						unnamedComponents: "arrow-function",
-					},
-				],
-				[formatRuleName(`${formatPluginName("react")}/jsx-closing-bracket-location`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/jsx-curly-brace-presence`)]: [
-					"error",
-					{
-						children: "always",
-						propElementValues: "always",
-						props: "always",
-					},
-				],
-				[formatRuleName(`${formatPluginName("react")}/jsx-no-bind`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/jsx-no-undef`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-deprecated`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-invalid-html-attribute`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-is-mounted`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-this-in-sfc`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-typos`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/no-unescaped-entities`)]: "error",
-				// eslint-disable-next-line @elsikora-typescript/naming-convention
-				[formatRuleName(`${formatPluginName("react")}/prefer-stateless-function`)]: ["error", { ignorePureComponents: true }],
-				[formatRuleName(`${formatPluginName("react")}/require-default-props`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/require-render-return`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/self-closing-comp`)]: "error",
-				[formatRuleName(`${formatPluginName("react")}/state-in-constructor`)]: ["error", "never"],
-				[formatRuleName(`${formatPluginName("react")}/style-prop-object`)]: "error",
-			},
-		},
-		{
-			files: ["**/*.jsx", "**/*.tsx"],
-			rules: {
-				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/component-name`)]: ["error", "PascalCase"],
-				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename-extension`)]: ["error", { allow: "as-needed" }],
-				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename`)]: withNext ? "off" : "error",
-				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/use-state`)]: "error",
-			},
-		},
-		{
-			// @ts-ignore
-			...formatConfig([react.configs["recommended-type-checked"]])[0],
-			files: ["**/*.ts", "**/*.tsx"],
-			languageOptions: {
-				parser: tseslint.parser,
-				parserOptions: {
+	},
+	{
+		// @ts-ignore
+		...formatConfig([react.configs.recommended])[0],
+		files: ["**/*.js", "**/*.jsx"],
+		languageOptions: {
+			parserOptions: {
+				ecmaFeatures: {
 					// eslint-disable-next-line @elsikora-typescript/naming-convention
-					projectService: true,
+					jsx: true,
 				},
+				ecmaVersion: "latest",
 			},
 		},
-	] as Array<Linter.Config>;
-}
+	},
+	{
+		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+		rules: {
+			[formatRuleName(`${formatPluginName("@eslint-react/hooks-extra")}/no-direct-set-state-in-use-effect`)]: "error",
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/context-name`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/checked-requires-onchange-or-readonly`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/default-props-match-prop-types`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/function-component-definition`)]: [
+				"error",
+				{
+					namedComponents: "arrow-function",
+					unnamedComponents: "arrow-function",
+				},
+			],
+			[formatRuleName(`${formatPluginName("react")}/jsx-closing-bracket-location`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/jsx-curly-brace-presence`)]: [
+				"error",
+				{
+					children: "always",
+					propElementValues: "always",
+					props: "always",
+				},
+			],
+			[formatRuleName(`${formatPluginName("react")}/jsx-no-bind`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/jsx-no-undef`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-deprecated`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-invalid-html-attribute`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-is-mounted`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-this-in-sfc`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-typos`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/no-unescaped-entities`)]: "error",
+			// eslint-disable-next-line @elsikora-typescript/naming-convention
+			[formatRuleName(`${formatPluginName("react")}/prefer-stateless-function`)]: ["error", { ignorePureComponents: true }],
+			[formatRuleName(`${formatPluginName("react")}/require-default-props`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/require-render-return`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/self-closing-comp`)]: "error",
+			[formatRuleName(`${formatPluginName("react")}/state-in-constructor`)]: ["error", "never"],
+			[formatRuleName(`${formatPluginName("react")}/style-prop-object`)]: "error",
+		},
+	},
+	{
+		files: ["**/*.jsx", "**/*.tsx"],
+		rules: {
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/component-name`)]: ["error", "PascalCase"],
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename-extension`)]: ["error", { allow: "as-needed" }],
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename`)]: "error",
+			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/use-state`)]: "error",
+		},
+	},
+	{
+		// @ts-ignore
+		...formatConfig([react.configs["recommended-type-checked"]])[0],
+		files: ["**/*.ts", "**/*.tsx"],
+		languageOptions: {
+			parser: tseslint.parser,
+			parserOptions: {
+				// eslint-disable-next-line @elsikora-typescript/naming-convention
+				projectService: true,
+			},
+		},
+	},
+] as Array<Linter.Config>;


### PR DESCRIPTION
Changed the React ESLint configuration from a function to a direct array export, removing the special handling in the config factory. This simplifies the code and makes React configuration consistent with other plugins. Also enabled React in the main eslint config.