### PR TITLE
feat(react): implement support for nextjs configuration in react rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 		"eslint": "^9.21.0",
 		"eslint-plugin-n": "^17.16.2",
 		"eslint-plugin-ng-module-sort": "^1.3.1",
+		"eslint-plugin-react": "^7.37.4",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.4.3",
 		"memfs": "^4.17.0",

--- a/src/application/factory/config.factory.ts
+++ b/src/application/factory/config.factory.ts
@@ -4,6 +4,8 @@ import type { IConfigOptions } from "../../domain/interface/config-options.inter
 import type { TConfigLoader } from "../../domain/type/config-loader.type";
 import type { TConfigModule } from "../../domain/type/config-module.type";
 
+import loadConfig from "../../infrastructure/config/react";
+
 /**
  * Factory class for generating ESLint configurations based on provided options.
  * Maps configuration flags to their respective module loaders and dynamically imports
@@ -92,6 +94,10 @@ export class ConfigFactory {
 			// Check if the default export is a function or an array
 			if (typeof defaultExport === "function") {
 				// For react config, pass the withNext option
+				if (name === "react") {
+					return loadConfig(this.currentOptions?.withNext ?? false);
+				}
+
 				return defaultExport();
 			}
 

--- a/src/infrastructure/config/react.ts
+++ b/src/infrastructure/config/react.ts
@@ -8,92 +8,94 @@ import { formatConfig } from "../utility/format-config.utility";
 import { formatPluginName } from "../utility/format-plugin-name.utility";
 import { formatRuleName } from "../utility/format-rule-name.utility";
 
-export default [
-	{
-		settings: {
-			react: {
-				version: "detect",
+export default function loadConfig(withNext: boolean = false): Array<Linter.Config> {
+	return [
+		{
+			settings: {
+				react: {
+					version: "detect",
+				},
 			},
 		},
-	},
-	{
-		plugins: {
-			[formatPluginName("react")]: react2,
-		},
-	},
-	{
-		// @ts-ignore
-		...formatConfig([react.configs.recommended])[0],
-		files: ["**/*.js", "**/*.jsx"],
-		languageOptions: {
-			parserOptions: {
-				ecmaFeatures: {
-					// eslint-disable-next-line @elsikora-typescript/naming-convention
-					jsx: true,
-				},
-				ecmaVersion: "latest",
+		{
+			plugins: {
+				[formatPluginName("react")]: react2,
 			},
 		},
-	},
-	{
-		files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
-		rules: {
-			[formatRuleName(`${formatPluginName("@eslint-react/hooks-extra")}/no-direct-set-state-in-use-effect`)]: "error",
-			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/context-name`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/checked-requires-onchange-or-readonly`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/default-props-match-prop-types`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/function-component-definition`)]: [
-				"error",
-				{
-					namedComponents: "arrow-function",
-					unnamedComponents: "arrow-function",
+		{
+			// @ts-ignore
+			...formatConfig([react.configs.recommended])[0],
+			files: ["**/*.js", "**/*.jsx"],
+			languageOptions: {
+				parserOptions: {
+					ecmaFeatures: {
+						// eslint-disable-next-line @elsikora-typescript/naming-convention
+						jsx: true,
+					},
+					ecmaVersion: "latest",
 				},
-			],
-			[formatRuleName(`${formatPluginName("react")}/jsx-closing-bracket-location`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/jsx-curly-brace-presence`)]: [
-				"error",
-				{
-					children: "always",
-					propElementValues: "always",
-					props: "always",
-				},
-			],
-			[formatRuleName(`${formatPluginName("react")}/jsx-no-bind`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/jsx-no-undef`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-deprecated`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-invalid-html-attribute`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-is-mounted`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-this-in-sfc`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-typos`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/no-unescaped-entities`)]: "error",
-			// eslint-disable-next-line @elsikora-typescript/naming-convention
-			[formatRuleName(`${formatPluginName("react")}/prefer-stateless-function`)]: ["error", { ignorePureComponents: true }],
-			[formatRuleName(`${formatPluginName("react")}/require-default-props`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/require-render-return`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/self-closing-comp`)]: "error",
-			[formatRuleName(`${formatPluginName("react")}/state-in-constructor`)]: ["error", "never"],
-			[formatRuleName(`${formatPluginName("react")}/style-prop-object`)]: "error",
+			},
 		},
-	},
-	{
-		files: ["**/*.jsx", "**/*.tsx"],
-		rules: {
-			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/component-name`)]: ["error", "PascalCase"],
-			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename-extension`)]: ["error", { allow: "as-needed" }],
-			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename`)]: "error",
-			[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/use-state`)]: "error",
-		},
-	},
-	{
-		// @ts-ignore
-		...formatConfig([react.configs["recommended-type-checked"]])[0],
-		files: ["**/*.ts", "**/*.tsx"],
-		languageOptions: {
-			parser: tseslint.parser,
-			parserOptions: {
+		{
+			files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
+			rules: {
+				[formatRuleName(`${formatPluginName("@eslint-react/hooks-extra")}/no-direct-set-state-in-use-effect`)]: "error",
+				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/context-name`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/checked-requires-onchange-or-readonly`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/default-props-match-prop-types`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/function-component-definition`)]: [
+					"error",
+					{
+						namedComponents: "arrow-function",
+						unnamedComponents: "arrow-function",
+					},
+				],
+				[formatRuleName(`${formatPluginName("react")}/jsx-closing-bracket-location`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/jsx-curly-brace-presence`)]: [
+					"error",
+					{
+						children: "always",
+						propElementValues: "always",
+						props: "always",
+					},
+				],
+				[formatRuleName(`${formatPluginName("react")}/jsx-no-bind`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/jsx-no-undef`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-deprecated`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-invalid-html-attribute`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-is-mounted`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-this-in-sfc`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-typos`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/no-unescaped-entities`)]: "error",
 				// eslint-disable-next-line @elsikora-typescript/naming-convention
-				projectService: true,
+				[formatRuleName(`${formatPluginName("react")}/prefer-stateless-function`)]: ["error", { ignorePureComponents: true }],
+				[formatRuleName(`${formatPluginName("react")}/require-default-props`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/require-render-return`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/self-closing-comp`)]: "error",
+				[formatRuleName(`${formatPluginName("react")}/state-in-constructor`)]: ["error", "never"],
+				[formatRuleName(`${formatPluginName("react")}/style-prop-object`)]: "error",
 			},
 		},
-	},
-] as Array<Linter.Config>;
+		{
+			files: ["**/*.jsx", "**/*.tsx"],
+			rules: {
+				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/component-name`)]: ["error", "PascalCase"],
+				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename-extension`)]: ["error", { allow: "as-needed" }],
+				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/filename`)]: withNext ? "off" : "error",
+				[formatRuleName(`${formatPluginName("@eslint-react/naming-convention")}/use-state`)]: "error",
+			},
+		},
+		{
+			// @ts-ignore
+			...formatConfig([react.configs["recommended-type-checked"]])[0],
+			files: ["**/*.ts", "**/*.tsx"],
+			languageOptions: {
+				parser: tseslint.parser,
+				parserOptions: {
+					// eslint-disable-next-line @elsikora-typescript/naming-convention
+					projectService: true,
+				},
+			},
+		},
+	] as Array<Linter.Config>;
+}


### PR DESCRIPTION
Modified the React configuration to accept a `withNext` flag that disables certain rules that conflict with NextJS file naming conventions. Added the eslint-plugin-react dependency and updated config factory to properly handle React configuration with NextJS support.