### PR TITLE
refactor(tests): remove console logs and fix test assertions

### DIFF
--- a/src/application/factory/config.factory.ts
+++ b/src/application/factory/config.factory.ts
@@ -87,10 +87,8 @@ export class ConfigFactory {
 	private static async loadConfig(name: string): Promise<Array<Linter.Config>> {
 		try {
 			const module: TConfigModule = await this.CONFIG_MAPPING[name]();
-			const defaultExport: (() => Array<Linter.Config>) | Array<Linter.Config> = module.default(this.currentOptions);
-			console.log("PRIVATE");
 
-			return defaultExport;
+			return module.default(this.currentOptions);
 		} catch (error) {
 			console.warn(`Optional dependency for ${name} config is not installed:`, error);
 

--- a/src/test/e2e/eslint.test.ts
+++ b/src/test/e2e/eslint.test.ts
@@ -15,7 +15,6 @@ describe("ESLint Config E2E Tests", () => {
 
 			const results = await eslint.lintFiles([getFixturePath("javascript/valid/clean.fixture.js")]);
 
-			console.log("RESULTS", results[0].messages);
 			expect(results[0].errorCount).toBe(0);
 			expect(results[0].messages).toHaveLength(0);
 		});
@@ -41,7 +40,7 @@ describe("ESLint Config E2E Tests", () => {
 			const results = await eslint.lintFiles([getFixturePath("typescript/invalid/naming-convention.fixture.ts")]);
 
 			expect(results[0].errorCount).toBeGreaterThan(0);
-			expect(results[0].messages.some((msg) => msg.ruleId === "@elsikora-typescript/naming-convention")).toBe(true);
+			expect(results[0].messages.some((msg) => msg.ruleId === formatRuleName("@typescript-eslint/naming-convention"))).toBe(true);
 		});
 
 		it("should enforce function return types", async () => {
@@ -51,7 +50,7 @@ describe("ESLint Config E2E Tests", () => {
 
 			const results = await eslint.lintFiles([getFixturePath("typescript/invalid/explicit-function-return-type.fixture.ts")]);
 
-			expect(results[0].messages.some((msg) => msg.ruleId === "@elsikora-typescript/explicit-function-return-type")).toBe(true);
+			expect(results[0].messages.some((msg) => msg.ruleId === formatRuleName("@typescript-eslint/explicit-function-return-type"))).toBe(true);
 		});
 	});
 

--- a/src/test/e2e/fixture/javascript/valid/clean.fixture.js
+++ b/src/test/e2e/fixture/javascript/valid/clean.fixture.js
@@ -1,3 +1,2 @@
 const a = 5;
-const b = 5;
 console.log(a);

--- a/src/test/e2e/helper/get-fixture-path.helper.ts
+++ b/src/test/e2e/helper/get-fixture-path.helper.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 
 export function getFixturePath(...paths: Array<string>): string {
-	console.log("CALLED", paths);
 	return path.join(__dirname, "../fixture", ...paths);
 }


### PR DESCRIPTION
Removed debug console.log statements from config factory and test helpers. Fixed rule name format in TypeScript tests to use the correct naming convention for rule checking. Also simplified the clean fixture file by removing an unused variable.