### PR TITLE
refactor(eslint): update no-secrets rule patterns and config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,8 +34,6 @@ const config = {
 		"*.gif",
 		"*.svg",
 		"*.ico",
-		"*.md",
-		"*.mdx",
 		"tmp",
 		".temp",
 		"**/*.d.ts",

--- a/src/infrastructure/config/no-secrets.ts
+++ b/src/infrastructure/config/no-secrets.ts
@@ -20,10 +20,10 @@ export default function loadConfig(_config: IConfigOptions): Array<Linter.Config
 					"error",
 					{
 						patterns: {
-							ApiKey: /api[-_]?key/i,
-							Password: /password|passwd|pwd/i,
-							SecretKey: /secret[-_]?key/i,
-							Token: /token|access[-_]?token/i,
+							ApiKey: /(?:const|let|var)\s+API[-_]?KEY/i,
+							Password: /(?:const|let|var)\s+(?:PASSWORD|PASSWD|PWD)/i,
+							SecretKey: /(?:const|let|var)\s+SECRET[-_]?KEY/i,
+							Token: /(?:const|let|var)\s+(?:TOKEN|ACCESS[-_]?TOKEN)/i,
 						},
 					},
 				],
@@ -33,15 +33,9 @@ export default function loadConfig(_config: IConfigOptions): Array<Linter.Config
 					{
 						ignoreModules: true,
 						// eslint-disable-next-line @elsikora/typescript/no-magic-numbers
-						tolerance: 4,
+						tolerance: 5,
 					},
 				],
-			},
-		},
-		{
-			files: ["**/*.json"],
-			rules: {
-				[formatRuleName("no-secrets/no-secrets")]: ["error"],
 			},
 		},
 		{


### PR DESCRIPTION
Refined regex patterns for the no-secrets rule to be more specific by targeting variable declarations rather than any occurrence of sensitive words. This reduces false positives in detection.

Additional changes:
- Increased tolerance threshold from 4 to 5 for better balance
- Removed JSON files from no-secrets rule application
- Removed .md and .mdx from eslint ignore patterns to enable linting for markdown files.