### PR TITLE
chore(lint-staged): exclude changelog files from linting

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,7 +3,7 @@ export default {
 		const commands = [];
 		commands.push("prettier --write --ignore-unknown");
 
-		const filteredFiles = files.filter((file) => !file.includes("src/test/") && !file.includes("vitest"));
+		const filteredFiles = files.filter((file) => !file.includes("src/test/") && !file.includes("vitest") && !file.includes("CHANGELOG"));
 
 		const eslintFiles = filteredFiles.filter((file) => {
 			const validExtensions = ["js", "jsx", "mjs", "cjs", "ts", "tsx", "json", "jsonc", "yml", "yaml"];


### PR DESCRIPTION
Updated the lint-staged configuration to exclude CHANGELOG files from ESLint checks. This prevents unnecessary linting of auto-generated changelog files.