### PR TITLE
test(config): increase test timeout to 10000ms in test configs

### DIFF
--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		exclude: ["node_modules/**/*"],
 		root: ".",
 		watch: false,
+		testTimeout: 10000,
 	},
 	resolve: {
 		alias: {

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 		exclude: ["node_modules/**/*"],
 		root: ".",
 		watch: false,
+		testTimeout: 10000,
 		coverage: {
 			provider: "v8",
 			reporter: ["text", "json", "html"],


### PR DESCRIPTION
Added a testTimeout configuration of 10 seconds to both e2e and unit test configuration files to prevent tests from failing due to timeout on slower environments.