### PR TITLE
refactor(eslint): improve react linting rules with descriptions and a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
 		"eslint-plugin-jsx-a11y": "^6.0.0",
 		"eslint-plugin-n": "^17.0.0",
 		"eslint-plugin-ng-module-sort": "^1.0.0",
-		"eslint-plugin-no-secrets": "^2.2.1",
 		"eslint-plugin-react": "^7.0.0",
 		"eslint-plugin-storybook": "^0.11.0",
 		"eslint-plugin-typeorm-typescript": "^0.5.0"

--- a/src/infrastructure/config/css.ts
+++ b/src/infrastructure/config/css.ts
@@ -17,6 +17,7 @@ export default function loadConfig(): Array<Linter.Config> {
 			files: ["**/*.css"],
 			rules: {
 				[formatRuleName("css/no-invalid-at-rules")]: "off", // Disallow at-rules that are not allowed by the config.
+				[formatRuleName("css/require-baseline")]: "off", // Disabled because it's not useful for all projects.
 			},
 		},
 	] as Array<Linter.Config>;

--- a/src/infrastructure/config/react.ts
+++ b/src/infrastructure/config/react.ts
@@ -41,18 +41,18 @@ export default function loadConfig(config: IConfigOptions): Array<Linter.Config>
 		{
 			files: ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"],
 			rules: {
-				[formatRuleName("@eslint-react/hooks-extra/no-direct-set-state-in-use-effect")]: "error",
-				[formatRuleName("@eslint-react/naming-convention/context-name")]: "error",
-				[formatRuleName("react/checked-requires-onchange-or-readonly")]: "error",
-				[formatRuleName("react/default-props-match-prop-types")]: config.withNext ? "off" : "error",
+				[formatRuleName("@eslint-react/hooks-extra/no-direct-set-state-in-use-effect")]: "error", // Disallow direct setState in useEffect
+				[formatRuleName("@eslint-react/naming-convention/context-name")]: "error", // Enforce the naming of context providers
+				[formatRuleName("react/checked-requires-onchange-or-readonly")]: "error", // Enforce input elements using either onChange or readOnly
+				[formatRuleName("react/default-props-match-prop-types")]: config.withNext ? "off" : "error", // Enforce all defaultProps have a corresponding non-required PropType
 				[formatRuleName("react/function-component-definition")]: [
 					"error",
 					{
 						namedComponents: "arrow-function",
 						unnamedComponents: "arrow-function",
 					},
-				],
-				[formatRuleName("react/jsx-closing-bracket-location")]: "error",
+				], // Enforce the definition of a component with arrow functions
+				[formatRuleName("react/jsx-closing-bracket-location")]: "off", // Enforce the closing bracket location for JSX multiline elements
 				[formatRuleName("react/jsx-curly-brace-presence")]: [
 					"error",
 					{
@@ -60,31 +60,31 @@ export default function loadConfig(config: IConfigOptions): Array<Linter.Config>
 						propElementValues: "always",
 						props: "always",
 					},
-				],
-				[formatRuleName("react/jsx-no-bind")]: "error",
-				[formatRuleName("react/jsx-no-undef")]: "error",
-				[formatRuleName("react/no-deprecated")]: "error",
-				[formatRuleName("react/no-invalid-html-attribute")]: "error",
-				[formatRuleName("react/no-is-mounted")]: "error",
-				[formatRuleName("react/no-this-in-sfc")]: "error",
-				[formatRuleName("react/no-typos")]: "error",
-				[formatRuleName("react/no-unescaped-entities")]: "error",
-				[formatRuleName("react/prefer-stateless-function")]: ["error", { ignorePureComponents: true }],
-				[formatRuleName("react/react-in-jsx-scope")]: config.withNext ? "off" : "error",
-				[formatRuleName("react/require-default-props")]: "error",
-				[formatRuleName("react/require-render-return")]: "error",
-				[formatRuleName("react/self-closing-comp")]: "error",
-				[formatRuleName("react/state-in-constructor")]: ["error", "never"],
-				[formatRuleName("react/style-prop-object")]: "error",
+				], // Enforce curly braces or disallow unnecessary curly braces in JSX props and/or children
+				[formatRuleName("react/jsx-no-bind")]: "off", // Prevent usage of Function.prototype.bind and arrow functions in React component props
+				[formatRuleName("react/jsx-no-undef")]: "error", // Disallow undeclared variables in JSX
+				[formatRuleName("react/no-deprecated")]: "error", // Prevent usage of deprecated methods
+				[formatRuleName("react/no-invalid-html-attribute")]: "error", // Disallow invalid characters in props
+				[formatRuleName("react/no-is-mounted")]: "error", // Prevent usage of isMounted
+				[formatRuleName("react/no-this-in-sfc")]: "error", // Prevent this from being used in stateless functional components
+				[formatRuleName("react/no-typos")]: "error", // Prevent common typos
+				[formatRuleName("react/no-unescaped-entities")]: "error", // Disallow unescaped entities
+				[formatRuleName("react/prefer-stateless-function")]: ["error", { ignorePureComponents: true }], // Enforce stateless components to be written as a pure function
+				[formatRuleName("react/react-in-jsx-scope")]: config.withNext ? "off" : "error", // Prevent missing React when using JSX
+				[formatRuleName("react/require-default-props")]: "error", // Enforce a defaultProps definition for every prop that is not a required prop
+				[formatRuleName("react/require-render-return")]: "error", // Enforce ES5 or ES6 class for returning value in render function
+				[formatRuleName("react/self-closing-comp")]: "error", // Prevent extra closing tags for components without children
+				[formatRuleName("react/state-in-constructor")]: ["error", "never"], // Enforce state initialization style
+				[formatRuleName("react/style-prop-object")]: "error", // Enforce style prop value being an object
 			},
 		},
 		{
 			files: ["**/*.jsx", "**/*.tsx"],
 			rules: {
-				[formatRuleName("@eslint-react/naming-convention/component-name")]: ["error", "PascalCase"],
-				[formatRuleName("@eslint-react/naming-convention/filename-extension")]: ["error", { allow: "as-needed" }],
-				[formatRuleName("@eslint-react/naming-convention/filename")]: config.withNext ? "off" : "error",
-				[formatRuleName("@eslint-react/naming-convention/use-state")]: "error",
+				[formatRuleName("@eslint-react/naming-convention/component-name")]: ["error", "PascalCase"], // Enforce component naming conventions
+				[formatRuleName("@eslint-react/naming-convention/filename-extension")]: ["error", { allow: "as-needed" }], // Enforce filename conventions
+				[formatRuleName("@eslint-react/naming-convention/filename")]: config.withNext ? "off" : "error", // Enforce filename conventions
+				[formatRuleName("@eslint-react/naming-convention/use-state")]: "error", // Enforce the use of the useState hook
 			},
 		},
 		{


### PR DESCRIPTION
…djust rule settings

Added descriptive comments to React ESLint rules to clarify their purpose. Disabled jsx-closing-bracket-location and jsx-no-bind rules for more flexibility. Disabled css/require-baseline rule as it's not needed for all projects. Removed eslint-plugin-no-secrets dependency which was no longer in use.