### PR TITLE
refactor(i18next): update no-literal-string rule to apply in jsx-only…

### DIFF
--- a/src/infrastructure/config/i18next.ts
+++ b/src/infrastructure/config/i18next.ts
@@ -10,14 +10,6 @@ import { formatRuleName } from "../utility/format-rule-name.utility";
 export default function loadConfig(): Array<Linter.Config> {
 	return [
 		{
-			plugins: {
-				[formatPluginName("i18next")]: i18nextPlugin,
-			},
-			rules: {
-				[formatRuleName("i18next/no-literal-string")]: "error",
-			},
-		},
-		{
 			files: ["**/*.ts", "**/*.tsx"],
 			languageOptions: {
 				// @ts-ignore
@@ -25,6 +17,12 @@ export default function loadConfig(): Array<Linter.Config> {
 				parserOptions: {
 					projectService: true,
 				},
+			},
+			plugins: {
+				[formatPluginName("i18next")]: i18nextPlugin,
+			},
+			rules: {
+				[formatRuleName("i18next/no-literal-string")]: ["error", { mode: "jsx-only" }],
 			},
 		},
 		{
@@ -36,6 +34,12 @@ export default function loadConfig(): Array<Linter.Config> {
 					},
 					ecmaVersion: "latest",
 				},
+			},
+			plugins: {
+				[formatPluginName("i18next")]: i18nextPlugin,
+			},
+			rules: {
+				[formatRuleName("i18next/no-literal-string")]: ["error", { mode: "jsx-only" }],
 			},
 		},
 	];

--- a/src/test/unit/infrastructure/config/i18next.test.ts
+++ b/src/test/unit/infrastructure/config/i18next.test.ts
@@ -4,91 +4,96 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies
 vi.mock("eslint-plugin-i18next", () => ({
-  default: {
-    rules: {
-      "no-literal-string": { create: () => ({}) },
-    },
-  },
+	default: {
+		rules: {
+			"no-literal-string": { create: () => ({}) },
+		},
+	},
 }));
 
 vi.mock("typescript-eslint", () => ({
-  default: {
-    parser: {
-      parse: () => ({}),
-    },
-  },
-  parser: {
-    parse: () => ({}),
-  },
+	default: {
+		parser: {
+			parse: () => ({}),
+		},
+	},
+	parser: {
+		parse: () => ({}),
+	},
 }));
 
 // Mock utility functions
 vi.mock("../../../../infrastructure/utility/format-plugin-name.utility", () => ({
-  formatPluginName: vi.fn((name) => `@elsikora/${name}`),
+	formatPluginName: vi.fn((name) => `@elsikora/${name}`),
 }));
 
 vi.mock("../../../../infrastructure/utility/format-rule-name.utility", () => ({
-  formatRuleName: vi.fn((name) => name.replace(/^([\w-]+)\//, "@elsikora/$1/")),
+	formatRuleName: vi.fn((name) => name.replace(/^([\w-]+)\//, "@elsikora/$1/")),
 }));
 
 describe("I18nextConfig", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    vi.clearAllMocks();
-  });
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
 
-  it("should return an array of configs", async () => {
-    const module = await import("../../../../infrastructure/config/i18next.ts");
-    const loadConfig = module.default;
-    
-    const configs: Array<Linter.Config> = loadConfig({});
-    
-    expect(Array.isArray(configs)).toBe(true);
-    expect(configs.length).toBe(3);
-  });
+	it("should return an array of configs", async () => {
+		const module = await import("../../../../infrastructure/config/i18next.ts");
+		const loadConfig = module.default;
 
-  it("should configure the i18next plugin", async () => {
-    const formatPluginNameModule = await import("../../../../infrastructure/utility/format-plugin-name.utility");
-    const module = await import("../../../../infrastructure/config/i18next.ts");
-    const loadConfig = module.default;
-    
-    loadConfig({});
-    
-    // Check plugin name formatting was called
-    expect(formatPluginNameModule.formatPluginName).toHaveBeenCalledWith("i18next");
-  });
+		const configs: Array<Linter.Config> = loadConfig({});
 
-  it("should include i18next rules for localization", async () => {
-    const formatRuleNameModule = await import("../../../../infrastructure/utility/format-rule-name.utility");
-    const module = await import("../../../../infrastructure/config/i18next.ts");
-    const loadConfig = module.default;
-    
-    const configs: Array<Linter.Config> = loadConfig({});
-    
-    // Check rule name formatting was called
-    expect(formatRuleNameModule.formatRuleName).toHaveBeenCalledWith("i18next/no-literal-string");
-    
-    // Check rule configuration
-    const firstConfig = configs[0];
-    expect(firstConfig.rules).toHaveProperty("@elsikora/i18next/no-literal-string", "error");
-  });
+		expect(Array.isArray(configs)).toBe(true);
+		expect(configs.length).toBe(2);
+	});
 
-  it("should include specific file patterns for different configs", async () => {
-    const module = await import("../../../../infrastructure/config/i18next.ts");
-    const loadConfig = module.default;
-    
-    const configs: Array<Linter.Config> = loadConfig({});
-    
-    // Check TS/TSX-specific config
-    const tsConfig = configs[1];
-    expect(tsConfig).toHaveProperty("files", ["**/*.ts", "**/*.tsx"]);
-    expect(tsConfig.languageOptions).toHaveProperty("parser");
-    expect(tsConfig.languageOptions?.parserOptions).toHaveProperty("projectService", true);
-    
-    // Check JS/JSX-specific config
-    const jsConfig = configs[2];
-    expect(jsConfig).toHaveProperty("files", ["**/*.js", "**/*.jsx"]);
-    expect(jsConfig.languageOptions?.parserOptions).toHaveProperty("ecmaFeatures.jsx", true);
-    expect(jsConfig.languageOptions?.parserOptions).toHaveProperty("ecmaVersion", "latest");
-  });
+	it("should configure the i18next plugin", async () => {
+		const formatPluginNameModule = await import("../../../../infrastructure/utility/format-plugin-name.utility");
+		const module = await import("../../../../infrastructure/config/i18next.ts");
+		const loadConfig = module.default;
+
+		loadConfig({});
+
+		// Check plugin name formatting was called
+		expect(formatPluginNameModule.formatPluginName).toHaveBeenCalledWith("i18next");
+	});
+
+	it("should include i18next rules for localization", async () => {
+		const formatRuleNameModule = await import("../../../../infrastructure/utility/format-rule-name.utility");
+		const module = await import("../../../../infrastructure/config/i18next.ts");
+		const loadConfig = module.default;
+
+		const configs: Array<Linter.Config> = loadConfig({});
+
+		// Check rule name formatting was called
+		expect(formatRuleNameModule.formatRuleName).toHaveBeenCalledWith("i18next/no-literal-string");
+
+		// Check rule configuration
+		const firstConfig = configs[0];
+		expect(firstConfig.rules).toHaveProperty("@elsikora/i18next/no-literal-string", [
+			"error",
+			{
+				mode: "jsx-only",
+			},
+		]);
+	});
+
+	it("should include specific file patterns for different configs", async () => {
+		const module = await import("../../../../infrastructure/config/i18next.ts");
+		const loadConfig = module.default;
+
+		const configs: Array<Linter.Config> = loadConfig({});
+
+		// Check TS/TSX-specific config
+		const tsConfig = configs[0];
+		expect(tsConfig).toHaveProperty("files", ["**/*.ts", "**/*.tsx"]);
+		expect(tsConfig.languageOptions).toHaveProperty("parser");
+		expect(tsConfig.languageOptions?.parserOptions).toHaveProperty("projectService", true);
+
+		// Check JS/JSX-specific config
+		const jsConfig = configs[1];
+		expect(jsConfig).toHaveProperty("files", ["**/*.js", "**/*.jsx"]);
+		expect(jsConfig.languageOptions?.parserOptions).toHaveProperty("ecmaFeatures.jsx", true);
+		expect(jsConfig.languageOptions?.parserOptions).toHaveProperty("ecmaVersion", "latest");
+	});
 });


### PR DESCRIPTION
### **User description**
… mode

Moved i18next plugin configuration from global scope to language-specific configs and updated the rule to only check for literal strings in JSX contexts. This prevents excessive warnings in non-JSX code while maintaining localization requirements in UI components.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Updated `i18next` plugin configuration for JSX-only mode.

- Refactored ESLint configuration to be language-specific.

- Adjusted unit tests to validate new configuration structure.

- Improved rule application for better localization enforcement.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>i18next.ts</strong><dd><code>Refactored i18next plugin configuration for JSX-only mode</code></dd></summary>
<hr>

src/infrastructure/config/i18next.ts

<li>Moved <code>i18next</code> plugin configuration to language-specific sections.<br> <li> Updated <code>no-literal-string</code> rule to <code>jsx-only</code> mode.<br> <li> Removed global configuration for <code>i18next</code> plugin.


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/ESLint-Config/pull/215/files#diff-592d9864d123bdaf0cae5b1a3b0ecd6729c45166797e1224ddc639e582899adc">+12/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>i18next.test.ts</strong><dd><code>Updated unit tests for i18next configuration changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/unit/infrastructure/config/i18next.test.ts

<li>Updated tests to reflect new <code>i18next</code> configuration structure.<br> <li> Adjusted assertions for <code>jsx-only</code> mode in <code>no-literal-string</code> rule.<br> <li> Reduced expected configurations from 3 to 2.


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/ESLint-Config/pull/215/files#diff-045739f7c37c03df7415c44bc42942e45a5391279ae54a10e37130dafe423083">+80/-75</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>