### PR TITLE
chore(typescript): support uppercase boolean prefixes in naming rules

### DIFF
--- a/src/infrastructure/config/typescript.ts
+++ b/src/infrastructure/config/typescript.ts
@@ -49,7 +49,7 @@ export default function loadConfig(config: IConfigOptions): Array<Linter.Config>
 						regex: "^match$",
 					},
 					format: null,
-					prefix: ["is", "should", "has", "can", "did", "will", "use", "with", "to", "was"],
+					prefix: ["is", "should", "has", "can", "did", "will", "use", "with", "to", "was", "IS", "SHOULD", "HAS", "CAN", "DID", "WILL", "USE", "WITH", "TO", "WAS"],
 					selector: ["variable", "parameter", "property", "parameterProperty", "accessor", "classProperty"],
 					types: ["boolean"],
 				},


### PR DESCRIPTION
### **User description**
Added uppercase versions of boolean variable prefixes to the typescript configuration. This allows developers to use uppercase prefixes for boolean variables while maintaining consistency with the established naming conventions.


___

### **PR Type**
enhancement


___

### **Description**
- Added support for uppercase boolean prefixes in TypeScript naming rules.

- Updated TypeScript configuration to include uppercase prefix options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>typescript.ts</strong><dd><code>Add uppercase boolean prefixes to TypeScript configuration</code></dd></summary>
<hr>

src/infrastructure/config/typescript.ts

<li>Added uppercase boolean prefixes to the <code>prefix</code> array.<br> <li> Ensures consistency with established naming conventions.


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/ESLint-Config/pull/218/files#diff-719c6b3d2e0a57e1213671214c224c4c887e9978d0ffc82632785f1c4df4376e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>