### PR TITLE
feat(branch-lint): add git branch linting capability

### DIFF
--- a/.elsikora/git-branch-lint.config.js
+++ b/.elsikora/git-branch-lint.config.js
@@ -1,0 +1,17 @@
+export default {
+	branches: {
+		bugfix: { description: "🆕 Integration of new functionality", title: "Feature" },
+		feature: { description: "🐞 Fixing issues in existing functionality", title: "Bugfix" },
+		hotfix: { description: "🚑 Critical fixes for urgent issues", title: "Hotfix" },
+		release: { description: "📦 Preparing a new release version", title: "Release" },
+		support: { description: "🛠️ Support and maintenance tasks", title: "Support" },
+	},
+	ignore: ["dev"],
+	rules: {
+		"branch-max-length": 50,
+		"branch-min-length": 5,
+		"branch-pattern": ":type/:name",
+		"branch-prohibited": ["main", "master", "release"],
+		"branch-subject-pattern": "[a-z0-9-]+",
+	},
+};

--- a/.elsikora/setup-wizard.config.js
+++ b/.elsikora/setup-wizard.config.js
@@ -1,4 +1,7 @@
 export default {
+	"branch-lint": {
+		isEnabled: true,
+	},
 	ci: {
 		isEnabled: true,
 		isNpmPackage: true,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"./dist"
 	],
 	"scripts": {
+		"branch": "npx @elsikora/git-branch-lint -b",
 		"prebuild": "rimraf dist",
 		"build": "npm run prebuild && rollup -c",
 		"build:test": "npm run prebuild && rollup -c rollup.test.config.js",
@@ -97,9 +98,10 @@
 		"@commitlint/format": "^19.8.0",
 		"@commitlint/types": "^19.8.0",
 		"@conarti/eslint-plugin-feature-sliced": "^1.0.5",
-		"@elsikora/commitizen-plugin-commitlint-ai": "^1.0.0",
+		"@elsikora/commitizen-plugin-commitlint-ai": "^1.2.0",
 		"@elsikora/eslint-plugin-css": "^0.6.2",
 		"@elsikora/eslint-plugin-nestjs-typed": "^3.0.1",
+		"@elsikora/git-branch-lint": "^1.1.0",
 		"@eslint-react/eslint-plugin": "^1.43.0",
 		"@eslint/core": "^0.13.0",
 		"@next/eslint-plugin-next": "^15.3.0",


### PR DESCRIPTION
Added git-branch-lint configuration and integration with the setup wizard. This enables branch naming convention enforcement with predefined branch types and validation rules. Added a new 'branch' script command to run the linting tool.