### PR TITLE
feat(config): add naming rules for abstract classes with base suffix

### DIFF
--- a/src/infrastructure/config/typescript-strict.ts
+++ b/src/infrastructure/config/typescript-strict.ts
@@ -116,10 +116,24 @@ export default function loadConfig(config: IConfigOptions): Array<Linter.Config>
 					selector: "variable", // Constants should be in UPPER_CASE and use camelCase for variables.
 				},
 				{
+					filter: {
+						match: false,
+						regex: "Base$",
+					},
 					format: ["PascalCase"],
 					modifiers: ["abstract"],
 					prefix: ["Abstract"],
-					selector: "class", // Abstract classes should use PascalCase and be prefixed with 'Abstract'.
+					selector: "class", // Classes should use PascalCase and be prefixed with 'Abstract'.
+				},
+				{
+					filter: {
+						match: false,
+						regex: "^Abstract",
+					},
+					format: ["PascalCase"],
+					modifiers: ["abstract"],
+					selector: "class",
+					suffix: ["Base"], // Classes should use PascalCase and be suffixed with 'Base'.
 				},
 				{
 					filter: {


### PR DESCRIPTION
Added ESLint naming convention rules for abstract classes that don't follow the 'Abstract' prefix pattern. These classes must now use the 'Base' suffix instead. This provides an alternative naming pattern for abstract classes while maintaining consistency.